### PR TITLE
Optimize frequent array_shift calls

### DIFF
--- a/Helper/FastBuffer.php
+++ b/Helper/FastBuffer.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Helper;
+
+/**
+ * FastBuffer class provides an efficient way to process array elements sequentially,
+ * avoiding the performance overhead of array_shift for large arrays.
+ */
+class FastBuffer
+{
+    /**
+     * @var array The internal array buffer.
+     */
+    public array $buffer;
+
+    /**
+     * @var int The current read offset in the buffer.
+     */
+    public int $offset;
+
+    /**
+     * @var int The total length of the buffer.
+     */
+    public int $length;
+
+    /**
+     * Constructor.
+     *
+     * @param array $data The array to be buffered.
+     */
+    public function __construct(array $data)
+    {
+        $this->buffer = array_values($data); // Re-index to ensure numeric, sequential keys
+        $this->offset = 0;
+        $this->length = count($data);
+    }
+
+    /**
+     * Shifts an element off the beginning of the buffer.
+     * This method is similar to array_shift but operates by incrementing an internal offset,
+     * making it more efficient for large arrays as it avoids re-indexing.
+     *
+     * @return mixed|null The shifted element, or null if the buffer is empty.
+     */
+    public function shift()
+    {
+        if ($this->offset < $this->length) {
+            return $this->buffer[$this->offset++];
+        }
+        return null;
+    }
+
+    /**
+     * Returns the number of remaining elements in the buffer.
+     *
+     * @return int The number of elements left to be shifted.
+     */
+    public function count(): int
+    {
+        return $this->length - $this->offset;
+    }
+
+    /**
+     * Checks if the buffer is empty.
+     *
+     * @return bool True if the buffer has no more elements, false otherwise.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->length === $this->offset;
+    }
+
+    /**
+     * Resets the buffer's read offset to the beginning.
+     */
+    public function reset(): void
+    {
+        $this->offset = 0;
+    }
+
+    /**
+     * Returns the entire remaining buffer as an array.
+     *
+     * @return array The remaining elements in the buffer.
+     */
+    public function getRemaining(): array
+    {
+        return array_slice($this->buffer, $this->offset);
+    }
+
+    /**
+     * Reads a null-terminated string from the buffer.
+     *
+     * @return string The read string.
+     */
+    /**
+     * Reads a null-terminated string from the buffer efficiently.
+     *
+     * @return string The read string.
+     */
+    public function readString(): string
+    {
+        $startOffset = $this->offset;
+        $endOffset = $this->offset;
+
+        // Find the null terminator or end of buffer
+        while ($endOffset < $this->length && $this->buffer[$endOffset] !== 0) {
+            $endOffset++;
+        }
+
+        // Extract the relevant portion of the buffer
+        $stringBytes = array_slice($this->buffer, $startOffset, $endOffset - $startOffset);
+
+        // Convert bytes to characters and join them
+        $result = implode('', array_map('chr', $stringBytes));
+
+        // Update the offset to after the null terminator (if found) or end of buffer
+        $this->offset = $endOffset + ($endOffset < $this->length && $this->buffer[$endOffset] === 0 ? 1 : 0);
+
+        return $result;
+    }
+
+    /**
+     * Reads a fixed-length string from the buffer.
+     *
+     * @param int $length The number of bytes to read.
+     * @return string The read string.
+     */
+    public function readFixedLengthString(int $length): string
+    {
+        if ($this->offset + $length > $this->length) {
+            // Not enough bytes left in the buffer
+            $length = $this->length - $this->offset;
+        }
+
+        $stringBytes = array_slice($this->buffer, $this->offset, $length);
+        $result = implode('', array_map('chr', $stringBytes));
+        $this->offset += $length;
+
+        return $result;
+    }
+}

--- a/Helper/FastBuffer.php
+++ b/Helper/FastBuffer.php
@@ -89,11 +89,6 @@ class FastBuffer
     }
 
     /**
-     * Reads a null-terminated string from the buffer.
-     *
-     * @return string The read string.
-     */
-    /**
      * Reads a null-terminated string from the buffer efficiently.
      *
      * @return string The read string.

--- a/Helper/FastBuffer.php
+++ b/Helper/FastBuffer.php
@@ -134,4 +134,33 @@ class FastBuffer
 
         return $result;
     }
+
+    /**
+     * Unshifts bytes into the buffer by overwriting content before the current cursor.
+     * The offset is moved backward by the number of unshifted bytes.
+     * The total length of the buffer remains unchanged.
+     *
+     * @param array $bytes The array of bytes to unshift.
+     * @throws \RangeException If the operation would result in a negative offset.
+     */
+    public function unshift(array $bytes): void
+    {
+        $numBytes = count($bytes);
+        $newOffset = $this->offset - $numBytes;
+
+        if ($newOffset < 0) {
+            throw new \RangeException("We assume we are never going to overshoot the beginning of the string.");
+        }
+
+        // Overwrite content before the current cursor
+        for ($i = 0; $i < $numBytes; $i++) {
+            if (isset($bytes[$i])) {
+                $this->buffer[$newOffset + $i] = $bytes[$i];
+            }
+        }
+
+        // Move offset backward
+        $this->offset = $newOffset;
+        // Length remains unchanged as per requirement
+    }
 }

--- a/Ws2/Opcodes/AbstractNullByteText.php
+++ b/Ws2/Opcodes/AbstractNullByteText.php
@@ -6,7 +6,7 @@ namespace Ws2\Opcodes;
  */
 abstract class AbstractNullByteText extends AbstractOpcode
 {
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$string, $len] = $this->reader->readString($dataSource);
         $this->compiledSize = 1 + $len;

--- a/Ws2/Opcodes/AbstractOpcode.php
+++ b/Ws2/Opcodes/AbstractOpcode.php
@@ -61,7 +61,7 @@ abstract class AbstractOpcode
     /**
      * @throws Exception
      */
-    abstract public function decompile(array &$dataSource): self;
+    abstract public function decompile(\Helper\FastBuffer &$dataSource): self;
 
     abstract public function preCompile(?string $params = null): self;
 

--- a/Ws2/Opcodes/AddMessageToLog.php
+++ b/Ws2/Opcodes/AddMessageToLog.php
@@ -9,7 +9,7 @@ class AddMessageToLog extends AbstractMessage
     public const OPCODE = '18';
     public const FUNC = 'AddMessageToLog';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $config = $this->reader->readData($dataSource, 1);
         [$message, $length] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/BackgroundMessage.php
+++ b/Ws2/Opcodes/BackgroundMessage.php
@@ -10,7 +10,7 @@ class BackgroundMessage extends AbstractMessage
     public const OPCODE = '3B';
     public const FUNC = 'BackgroundMessage';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $length] = $this->reader->readString($dataSource);
         [$message, $messageLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/CharMessageStart.php
+++ b/Ws2/Opcodes/CharMessageStart.php
@@ -12,7 +12,7 @@ class CharMessageStart extends AbstractOpcode
     public const OPCODE = '2E';
     public const FUNC = 'CharMessageStart';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $this->compiledSize = 1;
         $this->content = static::FUNC;

--- a/Ws2/Opcodes/Condition.php
+++ b/Ws2/Opcodes/Condition.php
@@ -9,7 +9,7 @@ class Condition extends AbstractOpcodeWithPointer
     public const OPCODE = '01';
     public const FUNC = 'Condition';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$configValue] = $this->reader->readData($dataSource, 1);
         $this->compiledSize = 2;

--- a/Ws2/Opcodes/Condition.php
+++ b/Ws2/Opcodes/Condition.php
@@ -15,7 +15,7 @@ class Condition extends AbstractOpcodeWithPointer
         $this->compiledSize = 2;
         $this->content = static::FUNC . " ({$configValue}";
         // The "$configValue === 3" part is validation for mainmenu vs HOT_001 - one has IF, another doesn't.
-        if (in_array($configValue, [2,128,129,130], true) || ($configValue === 3 && in_array($dataSource[0],[50,51,127,128], true))) {
+        if (in_array($configValue, [2,128,129,130], true) || ($configValue === 3 && in_array($dataSource->buffer[0],[50,51,127,128], true))) {
             $globalId = $this->reader->readWord($dataSource);
             $float = $this->reader->readFloat($dataSource); // Block id for CG_PAGES
             $pointer1 = $this->reader->readDWord($dataSource);

--- a/Ws2/Opcodes/ConditionalJump.php
+++ b/Ws2/Opcodes/ConditionalJump.php
@@ -9,7 +9,7 @@ class ConditionalJump extends AbstractOpcodeWithPointer
     public const OPCODE = 'E6';
     public const FUNC = 'ConditionalJump';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $pointerId = $this->reader->readDWord($dataSource);
         $pointerId2 = $this->reader->readDWord($dataSource);

--- a/Ws2/Opcodes/DisplayCharacterImage.php
+++ b/Ws2/Opcodes/DisplayCharacterImage.php
@@ -9,7 +9,7 @@ class DisplayCharacterImage extends AbstractOpcode
     public const OPCODE = '39';
     public const FUNC = 'DisplayCharacterImage';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $config = $this->reader->readData($dataSource, 3);

--- a/Ws2/Opcodes/DisplayMessage.php
+++ b/Ws2/Opcodes/DisplayMessage.php
@@ -9,7 +9,7 @@ class DisplayMessage extends AbstractMessage
     public const OPCODE = '14';
     public const FUNC = 'DisplayMessage';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $messageId = $this->reader->readDWord($dataSource);
         [$layer, $length] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/DisplayMessage.php
+++ b/Ws2/Opcodes/DisplayMessage.php
@@ -28,7 +28,7 @@ class DisplayMessage extends AbstractMessage
         $this->textExtractor?->setMessage($message);
         $return = static::FUNC . " ($messageId, $layer, $type\n{$message}\n);";
         if ($this->updateMode > 0 && $this->version == 1.0) {
-            array_unshift($dataSource, 0x15, 0);
+            $dataSource->unshift([0x15, 0]);
             $this->compiledSize -= 2;
         }
         $this->content = $return;

--- a/Ws2/Opcodes/DragBackground.php
+++ b/Ws2/Opcodes/DragBackground.php
@@ -12,7 +12,7 @@ class DragBackground extends AbstractOpcode
     public const OPCODE = '45';
     public const FUNC = 'DragBackground';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $config = $this->reader->readData($dataSource, 2);

--- a/Ws2/Opcodes/Effect1.php
+++ b/Ws2/Opcodes/Effect1.php
@@ -13,7 +13,7 @@ class Effect1 extends AbstractOpcode
     public const OPCODE = '47';
     public const FUNC = 'Effect1';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$effectName, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/Effect2.php
+++ b/Ws2/Opcodes/Effect2.php
@@ -13,7 +13,7 @@ class Effect2 extends AbstractOpcode
     public const OPCODE = '48';
     public const FUNC = 'Effect2';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$effectName, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/Effect3.php
+++ b/Ws2/Opcodes/Effect3.php
@@ -12,7 +12,7 @@ class Effect3 extends AbstractOpcode
     public const OPCODE = '58';
     public const FUNC = 'Effect3';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$effectName, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/ExecuteFunction.php
+++ b/Ws2/Opcodes/ExecuteFunction.php
@@ -10,7 +10,7 @@ class ExecuteFunction extends AbstractOpcode
     public const OPCODE = '1C';
     public const FUNC = 'ExecuteFunction';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$function, $len] = $this->reader->readString($dataSource);
         [$string, $strLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/FileEnd.php
+++ b/Ws2/Opcodes/FileEnd.php
@@ -8,7 +8,7 @@ class FileEnd extends AbstractOpcode
     public const OPCODE = 'FF';
     public const FUNC = 'FileEnd';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $someId = $this->reader->readDWord($dataSource);
         $configBytes = $this->reader->readData($dataSource, 4);

--- a/Ws2/Opcodes/InitKeyName.php
+++ b/Ws2/Opcodes/InitKeyName.php
@@ -9,7 +9,7 @@ class InitKeyName extends AbstractOpcode
     public const OPCODE = '5B';
     public const FUNC = 'InitKeyName';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$keyName, $len] = $this->reader->readString($dataSource);
         $id = $this->reader->readWord($dataSource);

--- a/Ws2/Opcodes/Jump.php
+++ b/Ws2/Opcodes/Jump.php
@@ -9,7 +9,7 @@ class Jump extends AbstractOpcodeWithPointer
     public const OPCODE = '06';
     public const FUNC = 'Jump';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $pointerId = $this->reader->readDWord($dataSource);
         $this->compiledSize = 1 + 4;

--- a/Ws2/Opcodes/Jump2.php
+++ b/Ws2/Opcodes/Jump2.php
@@ -9,7 +9,7 @@ class Jump2 extends AbstractOpcodeWithPointer
     public const OPCODE = '02';
     public const FUNC = 'Jump2';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $pointer = $this->reader->readDWord($dataSource);
         $this->compiledSize = 1 + 4;

--- a/Ws2/Opcodes/LayerConfig.php
+++ b/Ws2/Opcodes/LayerConfig.php
@@ -10,7 +10,7 @@ class LayerConfig extends AbstractOpcode
     public const OPCODE = '09';
     public const FUNC = 'LayerConfig';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $config = $this->reader->readData($dataSource, 3);
         $float = $this->reader->readFloat($dataSource);

--- a/Ws2/Opcodes/LayersList.php
+++ b/Ws2/Opcodes/LayersList.php
@@ -8,7 +8,7 @@ class LayersList extends AbstractOpcode
     public const OPCODE = '3F';
     public const FUNC = 'LayersList';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$amount] = $this->reader->readData($dataSource, 1);
         $layers = [];

--- a/Ws2/Opcodes/MoveBackground.php
+++ b/Ws2/Opcodes/MoveBackground.php
@@ -12,7 +12,7 @@ class MoveBackground extends AbstractOpcode
     public const OPCODE = '46';
     public const FUNC = 'MoveBackground';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $config = $this->reader->readData($dataSource, 3);

--- a/Ws2/Opcodes/MusicUnk1.php
+++ b/Ws2/Opcodes/MusicUnk1.php
@@ -8,7 +8,7 @@ class MusicUnk1 extends AbstractOpcode
     public const OPCODE = '20';
     public const FUNC = 'MusicUnk1'; // Fade out?
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$nameId, $idLen] = $this->reader->readString($dataSource);
         $seconds = $this->reader->readFloat($dataSource);

--- a/Ws2/Opcodes/PlayMovie.php
+++ b/Ws2/Opcodes/PlayMovie.php
@@ -8,7 +8,7 @@ class PlayMovie extends AbstractOpcode
     public const OPCODE = '35';
     public const FUNC = 'PlayMovie';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$name, $len] = $this->reader->readString($dataSource);
         [$file, $filenameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/PlayMusic.php
+++ b/Ws2/Opcodes/PlayMusic.php
@@ -10,7 +10,7 @@ class PlayMusic extends AbstractOpcode
 
     protected ?int $validateKey = 1;
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$nameId, $idLen] = $this->reader->readString($dataSource);
         [$filename, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/PrepareBackgroundArea.php
+++ b/Ws2/Opcodes/PrepareBackgroundArea.php
@@ -12,7 +12,7 @@ class PrepareBackgroundArea extends AbstractOpcode
     public const OPCODE = '36';
     public const FUNC = 'PrepareBackgroundArea';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $floatWidth = $this->reader->readFloat($dataSource);

--- a/Ws2/Opcodes/RainStart.php
+++ b/Ws2/Opcodes/RainStart.php
@@ -8,7 +8,7 @@ class RainStart extends AbstractOpcode
     public const OPCODE = '56';
     public const FUNC = 'RainStart';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$string, $strLen] = $this->reader->readString($dataSource);
         $config = $this->reader->readData($dataSource, 7);

--- a/Ws2/Opcodes/SetBackground.php
+++ b/Ws2/Opcodes/SetBackground.php
@@ -11,7 +11,7 @@ class SetBackground extends AbstractOpcode
 
     protected ?int $validateKey = 1;
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$name, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/SetDisplayName.php
+++ b/Ws2/Opcodes/SetDisplayName.php
@@ -12,7 +12,7 @@ class SetDisplayName extends AbstractOpcode
     public const OPCODE = '15';
     public const FUNC = 'SetDisplayName';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$charName, $nameLen] = $this->reader->readString($dataSource);
         $this->compiledSize = 1 + $nameLen;

--- a/Ws2/Opcodes/SetFlag.php
+++ b/Ws2/Opcodes/SetFlag.php
@@ -9,7 +9,7 @@ class SetFlag extends AbstractOpcode
     public const OPCODE = '0B';
     public const FUNC = 'SetFlag';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $globalId = $this->reader->readWord($dataSource);
         [$value] = $this->reader->readData($dataSource, 1);

--- a/Ws2/Opcodes/SetMask.php
+++ b/Ws2/Opcodes/SetMask.php
@@ -11,7 +11,7 @@ class SetMask extends AbstractOpcode
 
     protected ?int $validateKey = 1;
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$name, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/SetPnaFile.php
+++ b/Ws2/Opcodes/SetPnaFile.php
@@ -9,7 +9,7 @@ class SetPnaFile extends AbstractOpcode
     public const OPCODE = '73';
     public const FUNC = 'SetPnaFile';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$layer, $layerLen] = $this->reader->readString($dataSource);
         [$filename, $nameLen] = $this->reader->readString($dataSource); // ?

--- a/Ws2/Opcodes/SetTimer.php
+++ b/Ws2/Opcodes/SetTimer.php
@@ -9,7 +9,7 @@ class SetTimer extends AbstractOpcode
     public const OPCODE = '11';
     public const FUNC = 'SetTimer';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$name, $len] = $this->reader->readString($dataSource);
         if ($this->version > 1.4) {

--- a/Ws2/Opcodes/SetVariable.php
+++ b/Ws2/Opcodes/SetVariable.php
@@ -9,7 +9,7 @@ class SetVariable extends AbstractOpcode
     public const OPCODE = '6E';
     public const FUNC = 'SetVariable';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$variable, $len] = $this->reader->readString($dataSource);
         [$value, $valueLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/ShowChoice.php
+++ b/Ws2/Opcodes/ShowChoice.php
@@ -12,7 +12,7 @@ class ShowChoice extends AbstractOpcodeWithPointer
     public const OPCODE = '0F';
     public const FUNC = 'ShowChoice';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$choiceAmount] = $this->reader->readData($dataSource, 1); // Assumed ???
         $choices = '';

--- a/Ws2/Opcodes/SoundEffect.php
+++ b/Ws2/Opcodes/SoundEffect.php
@@ -14,7 +14,7 @@ class SoundEffect extends AbstractOpcode
 
     protected ?int $validateKey = 1;
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$name, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/SoundUnk1.php
+++ b/Ws2/Opcodes/SoundUnk1.php
@@ -12,7 +12,7 @@ class SoundUnk1 extends AbstractOpcode
     public const OPCODE = '29';
     public const FUNC = 'SoundUnk1';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $float1 = $this->reader->readFloat($dataSource);

--- a/Ws2/Opcodes/SoundUnk2.php
+++ b/Ws2/Opcodes/SoundUnk2.php
@@ -12,7 +12,7 @@ class SoundUnk2 extends AbstractOpcode
     public const OPCODE = '2A';
     public const FUNC = 'SoundUnk2';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $float1 = $this->reader->readFloat($dataSource);

--- a/Ws2/Opcodes/StartTimer.php
+++ b/Ws2/Opcodes/StartTimer.php
@@ -9,7 +9,7 @@ class StartTimer extends AbstractOpcode
     public const OPCODE = '12';
     public const FUNC = 'StartTimer';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$name, $len] = $this->reader->readString($dataSource);
         $config = $this->reader->readData($dataSource, 2);

--- a/Ws2/Opcodes/StopMusic.php
+++ b/Ws2/Opcodes/StopMusic.php
@@ -8,7 +8,7 @@ class StopMusic extends AbstractOpcode
     public const OPCODE = '1F';
     public const FUNC = 'StopMusic';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$nameId, $idLen] = $this->reader->readString($dataSource);
         $seconds = $this->reader->readFloat($dataSource);

--- a/Ws2/Opcodes/Unk16.php
+++ b/Ws2/Opcodes/Unk16.php
@@ -9,7 +9,7 @@ class Unk16 extends AbstractOpcode
     public const OPCODE = '16';
     public const FUNC = 'Unk16';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $size = 1;
         if ($this->version > 1.0) {

--- a/Ws2/Opcodes/Unk42.php
+++ b/Ws2/Opcodes/Unk42.php
@@ -10,7 +10,7 @@ class Unk42 extends AbstractOpcode
     public const OPCODE = '42';
     public const FUNC = 'Unk42';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $config = $this->reader->readData($dataSource, 2);

--- a/Ws2/Opcodes/Unk4A.php
+++ b/Ws2/Opcodes/Unk4A.php
@@ -8,7 +8,7 @@ class Unk4A extends AbstractOpcode
     public const OPCODE = '4A';
     public const FUNC = 'Unk4A';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$name, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/Unk65.php
+++ b/Ws2/Opcodes/Unk65.php
@@ -9,7 +9,7 @@ class Unk65 extends AbstractOpcode
     public const OPCODE = '65';
     public const FUNC = 'C65';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $config = $this->reader->readData($dataSource, 3);
         $float = $this->reader->readFloat($dataSource);

--- a/Ws2/Opcodes/Unk67.php
+++ b/Ws2/Opcodes/Unk67.php
@@ -10,7 +10,7 @@ class Unk67 extends AbstractOpcode
     public const OPCODE = '67';
     public const FUNC = 'Unk67';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $config = $this->reader->readData($dataSource, 4);
         $float1 = $this->reader->readFloat($dataSource);

--- a/Ws2/Opcodes/Unk75.php
+++ b/Ws2/Opcodes/Unk75.php
@@ -9,7 +9,7 @@ class Unk75 extends AbstractOpcode
     public const OPCODE = '75';
     public const FUNC = 'Unk75'; // Set Variable From Another Variable?
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$name, $nameLen] = $this->reader->readString($dataSource);
         [$keyname, $keynameLen] = $this->reader->readString($dataSource); // ?

--- a/Ws2/Opcodes/Unk78.php
+++ b/Ws2/Opcodes/Unk78.php
@@ -9,7 +9,7 @@ class Unk78 extends AbstractOpcode
     public const OPCODE = '78';
     public const FUNC = 'Unk78';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$layer, $layerLen] = $this->reader->readString($dataSource);
         [$filename, $nameLen] = $this->reader->readString($dataSource); // ?

--- a/Ws2/Opcodes/Unk7A.php
+++ b/Ws2/Opcodes/Unk7A.php
@@ -9,7 +9,7 @@ class Unk7A extends AbstractOpcode
     public const OPCODE = '7A';
     public const FUNC = 'Unk7A';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$layer, $layerLen] = $this->reader->readString($dataSource);
         [$filename, $nameLen] = $this->reader->readString($dataSource); // ?

--- a/Ws2/Opcodes/Unk7B.php
+++ b/Ws2/Opcodes/Unk7B.php
@@ -9,7 +9,7 @@ class Unk7B extends AbstractOpcode
     public const OPCODE = '7B';
     public const FUNC = 'Unk7B';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$layer, $layerLen] = $this->reader->readString($dataSource);
         [$filename, $nameLen] = $this->reader->readString($dataSource); // ?

--- a/Ws2/Opcodes/Unk84.php
+++ b/Ws2/Opcodes/Unk84.php
@@ -9,7 +9,7 @@ class Unk84 extends AbstractOpcode
     public const OPCODE = '84';
     public const FUNC = 'Unk84';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$s1, $s1Len] = $this->reader->readString($dataSource);
         [$s2, $s2Len] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/Unk97.php
+++ b/Ws2/Opcodes/Unk97.php
@@ -9,7 +9,7 @@ class Unk97 extends AbstractOpcode
     public const OPCODE = '97';
     public const FUNC = 'Unk97';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $config = $this->reader->readData($dataSource, 3);
         $floats = $this->reader->readFloats($dataSource,4);

--- a/Ws2/Opcodes/UnkBackground1.php
+++ b/Ws2/Opcodes/UnkBackground1.php
@@ -12,7 +12,7 @@ class UnkBackground1 extends AbstractOpcode
     public const OPCODE = '57';
     public const FUNC = 'UnkBackground1';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $configBytes = $this->reader->readData($dataSource, 2);

--- a/Ws2/Opcodes/UnkBackground2.php
+++ b/Ws2/Opcodes/UnkBackground2.php
@@ -12,7 +12,7 @@ class UnkBackground2 extends AbstractOpcode
     public const OPCODE = '3A';
     public const FUNC = 'UnkBackground2';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         $configBytes = $this->reader->readData($dataSource, 2);

--- a/Ws2/Opcodes/UnkBackground3.php
+++ b/Ws2/Opcodes/UnkBackground3.php
@@ -12,7 +12,7 @@ class UnkBackground3 extends AbstractOpcode
     public const OPCODE = '41';
     public const FUNC = 'UnkBackground3';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         // @todo test KAN_2002.ws2
         [$channel, $channelLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/UnkScreen.php
+++ b/Ws2/Opcodes/UnkScreen.php
@@ -9,7 +9,7 @@ class UnkScreen extends AbstractOpcode
     public const OPCODE = 'F0';
     public const FUNC = 'UnkScreen';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         $config = $this->reader->readData($dataSource, 1);
         $this->compiledSize = 2;

--- a/Ws2/Opcodes/UsePnaPackage.php
+++ b/Ws2/Opcodes/UsePnaPackage.php
@@ -10,7 +10,7 @@ class UsePnaPackage extends AbstractOpcode
 
     protected ?int $validateKey = 1;
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$effectName, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/VariableUnk2.php
+++ b/Ws2/Opcodes/VariableUnk2.php
@@ -8,7 +8,7 @@ class VariableUnk2 extends AbstractOpcode
     public const OPCODE = '52';
     public const FUNC = 'VariableUnk2';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$channel, $channelLen] = $this->reader->readString($dataSource);
         [$variableName, $nameLen] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/VariableUnk3.php
+++ b/Ws2/Opcodes/VariableUnk3.php
@@ -8,7 +8,7 @@ class VariableUnk3 extends AbstractOpcode
     public const OPCODE = '38';
     public const FUNC = 'VariableUnk3';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$variable, $varLen] = $this->reader->readString($dataSource);
         $config = $this->reader->readData($dataSource, 1);

--- a/Ws2/Opcodes/VariableUnk4.php
+++ b/Ws2/Opcodes/VariableUnk4.php
@@ -8,7 +8,7 @@ class VariableUnk4 extends AbstractOpcode
     public const OPCODE = '53';
     public const FUNC = 'VariableUnk4';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$variable, $varLen] = $this->reader->readString($dataSource);
         [$variable2, $varLen2] = $this->reader->readString($dataSource);

--- a/Ws2/Opcodes/VariableUnk51.php
+++ b/Ws2/Opcodes/VariableUnk51.php
@@ -8,7 +8,7 @@ class VariableUnk51 extends AbstractOpcode
     public const OPCODE = '51';
     public const FUNC = 'VariableUnk51';
 
-    public function decompile(array &$dataSource): self
+    public function decompile(\Helper\FastBuffer &$dataSource): self
     {
         [$variable, $varLen] = $this->reader->readString($dataSource);
         [$variable2, $var2Len] = $this->reader->readString($dataSource);

--- a/Ws2/Struct.php
+++ b/Ws2/Struct.php
@@ -11,18 +11,21 @@ class Struct
 
     protected array $labels = [];
 
+    protected \Helper\FastBuffer $data;
+
     public function __construct(
         protected Reader $reader,
         protected OpcodesList $opcodesList,
-        protected array $data,
+        protected array $data_array,
         private TextExtractor $textExtractor,
         protected int $offset = 0,
     ) {
+        $this->data = new \Helper\FastBuffer($this->data_array);
     }
 
     public function generateScript(float $version, int $updateMode = 0, int $offset = 0): array
     {
-        $this->totalSize = count($this->data);
+        $this->totalSize = $this->data->count();
         $script = [];
         $isFileStart = true;
         // Only for title.ws2, as it has empty zero offset at the start which could not be read in normal ways
@@ -33,7 +36,7 @@ class Struct
             $offset --;
         }
         while($this->totalSize > 0) {
-            $command = array_shift($this->data);
+            $command = $this->data->shift();
             $hex = $this->reader->getHex($command);
             if ($isFileStart && $hex === '00') {
                 $isFileStart = false;
@@ -74,7 +77,7 @@ class Struct
 
     private function generateOutputLine(int $displayNumbers, int $perLine = 8): string
     {
-        if (empty($this->data)) {
+        if ($this->data->isEmpty()) {
             return 'Full script processed';
         }
         $lines = [];
@@ -84,10 +87,10 @@ class Struct
                 $result[] = implode(' ', $lines);
                 $lines = [];
             }
-            $command = array_shift($this->data);
+            $command = $this->data->shift();
             $hex = $this->reader->getHex($command);
             $lines[] = $hex;
-            if (empty($this->data)) {
+            if ($this->data->isEmpty()) {
                 break;
             }
         }


### PR DESCRIPTION
Decoding time on one of the ws2 file is reduced from 28s to 0.7s.

I haven't been writing PHP code for more than a decade so please be careful reviewing code.